### PR TITLE
Fix: base.css:1540 typo

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -1537,7 +1537,7 @@ Block highlight function
     font-weight: 600;
     padding: 0px !important;
 }
-.tippy-tooltip-content {l
+.tippy-tooltip-content {
     border-radius: 4px;
 }
 .tippy-wrapper {


### PR DESCRIPTION
Hello,  
I noticed a typo in `base.css` line `1540`

```diff
-   .tippy-tooltip-content {l
+   .tippy-tooltip-content {
```