### PR TITLE
typo:base.css:636 ';;'

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -633,7 +633,7 @@ blockquote:before {
 a[priority]:not(a[priority=""])::before, a.priority::before {
     font-size: 16px;
     font-family: 'tabler-icons';
-    vertical-align: bottom;;
+    vertical-align: bottom;
   }
   a[priority]:not(a[priority=""]), a.priority {
     font-size: 0px;


### PR DESCRIPTION
Noticed an additional character that looks like it was added by mistake.

Out of curiosity; Do you use a linter with your editor?